### PR TITLE
แก้เรื่อง update house แต่ดันใช้ตัวแปรไม่ใช่ house

### DIFF
--- a/ffc/src/main/kotlin/ffc/app/location/MarkLocationActivity.kt
+++ b/ffc/src/main/kotlin/ffc/app/location/MarkLocationActivity.kt
@@ -30,6 +30,7 @@ import ffc.app.R
 import ffc.app.R.id
 import ffc.app.R.layout
 import ffc.entity.Place
+import ffc.entity.place.House
 import ffc.entity.update
 import kotlinx.android.synthetic.main.activity_add_location.done
 import org.jetbrains.anko.alert
@@ -90,7 +91,12 @@ class MarkLocationActivity : FamilyFolderActivity() {
     private fun updateHouse() {
         val dialog = indeterminateProgressDialog("ปรับปรุงพิกัด...")
 
-        FfcCentral().service<PlaceService>().updateHouse(org!!.id, targetPlace!!).enqueue {
+        require(targetPlace is House) {
+            indeterminateProgressDialog("ไม่ใช่ Object ประเภทบ้าน แจ้งผู้ดูแลระบบ...")
+            "ไม่ใช่ Object ประเภทบ้าน"
+        }
+
+        FfcCentral().service<PlaceService>().updateHouse(org!!.id, targetPlace!! as House).enqueue {
             always { dialog.dismiss() }
             onSuccess {
                 setResult(Activity.RESULT_OK)

--- a/ffc/src/main/kotlin/ffc/app/location/PlaceService.kt
+++ b/ffc/src/main/kotlin/ffc/app/location/PlaceService.kt
@@ -17,7 +17,6 @@
 
 package ffc.app.location
 
-import ffc.entity.Place
 import ffc.entity.place.House
 import retrofit2.Call
 import retrofit2.http.Body
@@ -44,7 +43,7 @@ interface PlaceService {
     @PUT("org/{orgId}/house/{houseId}")
     fun updateHouse(
         @Path("orgId") orgId: String,
-        @Body place: Place,
-        @Path("houseId") houseId: String = place.id
+        @Body house: House,
+        @Path("houseId") houseId: String = house.id
     ): Call<House>
 }


### PR DESCRIPTION
แก้ไข bug Android เวลาปักพิกัดแล้ว รหัสบ้านจะหาย
สาเหตุ ไม่ได้ใช้ตัวแปรประเภท House
แก้ไข ใช้ตัวแปรประเภท House
อธิบาย เนื่องจากตัวแปรประเภท Place ไม่มีการเก็บรหัสบ้าน หากใช้ตัวแปร Place มาอัพเดทข้อมูล รหัสบ้านจะหายไป โครงสร้างคือ ตัวแปร House สืบทอดมาจาก Place เพื่อเติมข้อมูลเกี่ยวกับบ้านข้อไป ตัว Place จึงมีข้อมูลน้อยกว่า House